### PR TITLE
BDOG-741: Uplift application.conf for Play 2.6

### DIFF
--- a/app/uk/gov/hmrc/example/controllers/MicroserviceHelloWorld.scala
+++ b/app/uk/gov/hmrc/example/controllers/MicroserviceHelloWorld.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/example/repositories/ExampleRepository.scala
+++ b/app/uk/gov/hmrc/example/repositories/ExampleRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2019 HM Revenue & Customs
+# Copyright 2020 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -50,12 +50,6 @@ play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoHmrcModule"
 
 # play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoHmrcModule"
 
-# Session Timeout
-# ~~~~
-# The default session timeout for the app is 15 minutes (900seconds).
-# Updating this is the responsibility of the app - it must issue a new cookie with each request or the session will
-# timeout 15 minutes after login (regardless of user activity).
-# session.maxAge=900
 
 # Secret key
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -70,7 +70,7 @@ application.session.secure=false
 
 # The application languages
 # ~~~~~
-application.langs="en"
+play.i18n.langs=["en"]
 
 # Router
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,7 +61,7 @@ play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoHmrcModule"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret="xG1syrAzOT2sxfqvGrNmGMfx8Rwh31qBStiIXyL830ZOiQsJrmO9ad2ZyuWfuZWH"
+play.http.secret.key="xG1syrAzOT2sxfqvGrNmGMfx8Rwh31qBStiIXyL830ZOiQsJrmO9ad2ZyuWfuZWH"
 
 # Session configuration
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -104,24 +104,6 @@ controllers {
 }
 
 
-# Evolutions
-# ~~~~~
-# You can disable evolutions if needed
-# evolutionplugin=disabled
-
-# Logger
-# ~~~~~
-# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
-
-# Root logger:
-logger.root=ERROR
-
-# Logger used by the framework:
-logger.play=INFO
-
-# Logger provided to your application:
-logger.application=DEBUG
-
 # Metrics plugin settings - graphite reporting is configured on a per env basis
 metrics {
     name = ${appName}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -63,11 +63,6 @@ play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoHmrcModule"
 # If you deploy your application to several instances be sure to use the same key!
 play.http.secret.key="xG1syrAzOT2sxfqvGrNmGMfx8Rwh31qBStiIXyL830ZOiQsJrmO9ad2ZyuWfuZWH"
 
-# Session configuration
-# ~~~~~
-application.session.httpOnly=false
-application.session.secure=false
-
 # The application languages
 # ~~~~~
 play.i18n.langs=["en"]
@@ -153,5 +148,3 @@ microservice {
 
     }
 }
-
-

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -82,7 +82,7 @@ application.langs="en"
 # you may need to define a router file `conf/my.application.routes`.
 # Default to Routes in the root package (and conf/routes)
 # !!!WARNING!!! DO NOT CHANGE THIS ROUTER
-application.router=prod.Routes
+play.http.router=prod.Routes
 
 
 # Controller

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,16 +5,16 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-play-26"    % "0.36.0",
-    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.12.0-play-26",
+    "uk.gov.hmrc" %% "bootstrap-play-26"    % "1.6.0",
+    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.26.0-play-26",
     ws
   )
 
   val test = Seq(
-    "org.scalatest"     %% "scalatest"          % "3.0.5"             % Test,
+    "org.scalatest"     %% "scalatest"          % "3.0.8"             % Test,
     "org.pegdown"       % "pegdown"             % "1.6.0"             % Test,
     "com.typesafe.play" %% "play-test"          % PlayVersion.current % Test,
-    "uk.gov.hmrc"       %% "reactivemongo-test" % "4.8.0-play-26"     % Test
+    "uk.gov.hmrc"       %% "reactivemongo-test" % "4.19.0-play-26"    % Test
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,12 +5,12 @@ resolvers += Resolver.typesafeRepo("releases")
 
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")

--- a/test/uk/gov/hmrc/example/controllers/MicroserviceHelloWorldControllerSpec.scala
+++ b/test/uk/gov/hmrc/example/controllers/MicroserviceHelloWorldControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/example/repositories/ExampleRepositorySpec.scala
+++ b/test/uk/gov/hmrc/example/repositories/ExampleRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Although this was already a Play 2.6 project, it was an older version - so started with a general uplift of plugins & dependencies.

Then updated application.conf in accordance with the proposal for how init-service should generate config for backend services going forwards.